### PR TITLE
Add a check for raft leader status on store join

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -165,8 +165,13 @@ func (s *Store) Delete(key string) error {
 
 // Join joins a node, identified by nodeID and located at addr, to this store.
 // The node must be ready to respond to Raft communications at that address.
+// This command must be run on the leader, otherwise AddVoter will fail.
 func (s *Store) Join(nodeID, addr string) error {
 	s.logger.Printf("received join request for remote node %s at %s", nodeID, addr)
+
+	if s.raft.State() != raft.Leader {
+		return fmt.Errorf("not leader")
+	}
 
 	configFuture := s.raft.GetConfiguration()
 	if err := configFuture.Error(); err != nil {


### PR DESCRIPTION
On the store's [join method](https://github.com/otoolep/hraftd/blob/44855c43598e4958bfce262fc1ec034a6800746f/store/store.go#L168), it calls [`raft.AddVoter()`](https://godoc.org/github.com/hashicorp/raft#Raft.AddVoter):

https://github.com/otoolep/hraftd/blob/44855c43598e4958bfce262fc1ec034a6800746f/store/store.go#L195-L198

Which according to the documentation:

> AddVoter will add the given server to the cluster as a staging server. If the server is already in the cluster as a voter, this updates the server's address. **This must be run on the leader or it will fail.**

This PR simply adds a check at the top of the Join method to ensure that it can't be run on a non-leader. This error otherwise occurs if a node attempts to join a cluster by connecting to a raft node that isn't currently a leader.