### PR TITLE
feat: add /status endpoint

### DIFF
--- a/http/service.go
+++ b/http/service.go
@@ -119,7 +119,11 @@ func (s *Service) handleJoin(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
-	var status, err = s.store.Status()
+	if r.Method != "GET" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+
+	status, err := s.store.Status()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/http/service.go
+++ b/http/service.go
@@ -9,18 +9,9 @@ import (
 	"net"
 	"net/http"
 	"strings"
+
+	store "github.com/otoolep/hraftd/store"
 )
-
-type Node struct {
-	ID      string `json:"id"`
-	Address string `json:"address"`
-}
-
-type StoreStatus struct {
-	Me        Node   `json:"me"`
-	Leader    Node   `json:"leader"`
-	Followers []Node `json:"followers"`
-}
 
 // Store is the interface Raft-backed key-value stores must implement.
 type Store interface {
@@ -37,7 +28,7 @@ type Store interface {
 	Join(nodeID string, addr string) error
 
 	// Show who is me, the leader, and followers
-	Status() (StoreStatus, error)
+	Status() (store.StoreStatus, error)
 }
 
 // Service provides HTTP service.

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -86,6 +86,10 @@ func (t *testStore) Join(nodeID, addr string) error {
 	return nil
 }
 
+func (t *testStore) Status() ([]byte, error) {
+	return nil, nil
+}
+
 func doGet(t *testing.T, url, key string) string {
 	resp, err := http.Get(fmt.Sprintf("%s/key/%s", url, key))
 	if err != nil {

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	store "github.com/otoolep/hraftd/store"
 )
 
 // Test_NewServer tests that a server can perform all basic operations.
@@ -87,17 +89,17 @@ func (t *testStore) Join(nodeID, addr string) error {
 	return nil
 }
 
-func (t *testStore) Status() (StoreStatus, error) {
-	return StoreStatus{
-		Me: Node{
+func (t *testStore) Status() (store.StoreStatus, error) {
+	return store.StoreStatus{
+		Me: store.Node{
 			ID:      "01",
 			Address: "127.0.0.1:1210",
 		},
-		Leader: Node{
+		Leader: store.Node{
 			ID:      "01",
 			Address: "127.0.0.1:1210",
 		},
-		Followers: []Node{},
+		Followers: []store.Node{},
 	}, nil
 }
 
@@ -155,7 +157,7 @@ func doStatus(t *testing.T, url string) {
 		t.Fatalf("failed to read response: %s", err)
 	}
 
-	var status StoreStatus
+	var status store.StoreStatus
 	err = json.Unmarshal(body, &status)
 	if err != nil {
 		t.Fatalf("status is not a valid status json")

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -120,3 +120,51 @@ func Test_StoreInMemOpenSingleNode(t *testing.T) {
 		t.Fatalf("key has wrong value: %s", value)
 	}
 }
+
+func Test_StoreStatus(t *testing.T) {
+	s := New(false)
+	tmpDir, _ := ioutil.TempDir("", "store_test")
+	defer os.RemoveAll(tmpDir)
+
+	s.RaftBind = "127.0.0.1:0"
+	s.RaftDir = tmpDir
+	if s == nil {
+		t.Fatalf("failed to create store")
+	}
+
+	if err := s.Open(true, "node0"); err != nil {
+		t.Fatalf("failed to open store: %s", err)
+	}
+
+	// assuming 3 seconds enough for raft to initialized
+	time.Sleep(3 * time.Second)
+
+	status, err := s.Status()
+	if err != nil {
+		t.Errorf("failed to get store status: %s", err)
+	}
+
+	if status.Me.ID != "node0" {
+		t.Errorf("status `me.id` has invalid value")
+	}
+	if status.Me.Address != s.RaftBind {
+		t.Errorf("status `me.address` has invalid value")
+	}
+
+	for _, follower := range status.Followers {
+		if (follower.ID == status.Leader.ID) || (follower.Address == status.Leader.Address) {
+			t.Fatalf("a node cannot be leader and follow at the same time")
+		}
+	}
+
+	isMeInFollowersOrLeader := false
+	for _, node := range append(status.Followers, status.Leader) {
+		if node.ID == status.Me.ID && node.Address == status.Me.Address {
+			isMeInFollowersOrLeader = true
+			break
+		}
+	}
+	if !isMeInFollowersOrLeader {
+		t.Errorf("me must be exist exclusively as a leader or as a follower")
+	}
+}


### PR DESCRIPTION
the goal of /status is to provide detail about the raft. the current approach provides
- id and address about me
- id and address of the leader
- id and address of the followers