### PR TITLE
Replace deprecated code

### DIFF
--- a/http/service.go
+++ b/http/service.go
@@ -74,7 +74,6 @@ func (s *Service) Start() error {
 // Close closes the service.
 func (s *Service) Close() {
 	s.ln.Close()
-	return
 }
 
 // ServeHTTP allows Service to serve HTTP requests.
@@ -204,7 +203,6 @@ func (s *Service) handleKeyRequest(w http.ResponseWriter, r *http.Request) {
 	default:
 		w.WriteHeader(http.StatusMethodNotAllowed)
 	}
-	return
 }
 
 // Addr returns the address on which the Service is listening

--- a/http/service_test.go
+++ b/http/service_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,9 +17,6 @@ import (
 func Test_NewServer(t *testing.T) {
 	store := newTestStore()
 	s := &testServer{New(":0", store)}
-	if s == nil {
-		t.Fatal("failed to create HTTP service")
-	}
 
 	if err := s.Start(); err != nil {
 		t.Fatalf("failed to start HTTP service: %s", err)
@@ -109,7 +106,7 @@ func doGet(t *testing.T, url, key string) string {
 		t.Fatalf("failed to GET key: %s", err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("failed to read response: %s", err)
 	}
@@ -152,7 +149,7 @@ func doStatus(t *testing.T, url string) {
 		t.Fatalf("failed to fetch status: %s", err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("failed to read response: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -21,11 +21,13 @@ const (
 )
 
 // Command line parameters
-var inmem bool
-var httpAddr string
-var raftAddr string
-var joinAddr string
-var nodeID string
+var (
+	inmem    bool
+	httpAddr string
+	raftAddr string
+	joinAddr string
+	nodeID   string
+)
 
 func init() {
 	flag.BoolVar(&inmem, "inmem", false, "Use in-memory storage for Raft")
@@ -55,7 +57,7 @@ func main() {
 	if raftDir == "" {
 		log.Fatalln("No Raft storage directory specified")
 	}
-	if err := os.MkdirAll(raftDir, 0700); err != nil {
+	if err := os.MkdirAll(raftDir, 0o700); err != nil {
 		log.Fatalf("failed to create path for Raft storage: %s", err.Error())
 	}
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -10,14 +9,15 @@ import (
 // Test_StoreOpen tests that the store can be opened.
 func Test_StoreOpen(t *testing.T) {
 	s := New(false)
-	tmpDir, _ := ioutil.TempDir("", "store_test")
+	tmpDir, _ := os.MkdirTemp("", "store_test")
 	defer os.RemoveAll(tmpDir)
 
-	s.RaftBind = "127.0.0.1:0"
-	s.RaftDir = tmpDir
 	if s == nil {
 		t.Fatalf("failed to create store")
 	}
+
+	s.RaftBind = "127.0.0.1:0"
+	s.RaftDir = tmpDir
 
 	if err := s.Open(false, "node0"); err != nil {
 		t.Fatalf("failed to open store: %s", err)
@@ -27,14 +27,15 @@ func Test_StoreOpen(t *testing.T) {
 // Test_StoreOpenSingleNode tests that a command can be applied to the log
 func Test_StoreOpenSingleNode(t *testing.T) {
 	s := New(false)
-	tmpDir, _ := ioutil.TempDir("", "store_test")
+	tmpDir, _ := os.MkdirTemp("", "store_test")
 	defer os.RemoveAll(tmpDir)
 
-	s.RaftBind = "127.0.0.1:0"
-	s.RaftDir = tmpDir
 	if s == nil {
 		t.Fatalf("failed to create store")
 	}
+
+	s.RaftBind = "127.0.0.1:0"
+	s.RaftDir = tmpDir
 
 	if err := s.Open(true, "node0"); err != nil {
 		t.Fatalf("failed to open store: %s", err)
@@ -76,14 +77,15 @@ func Test_StoreOpenSingleNode(t *testing.T) {
 // stored in RAM.
 func Test_StoreInMemOpenSingleNode(t *testing.T) {
 	s := New(true)
-	tmpDir, _ := ioutil.TempDir("", "store_test")
+	tmpDir, _ := os.MkdirTemp("", "store_test")
 	defer os.RemoveAll(tmpDir)
 
-	s.RaftBind = "127.0.0.1:0"
-	s.RaftDir = tmpDir
 	if s == nil {
 		t.Fatalf("failed to create store")
 	}
+
+	s.RaftBind = "127.0.0.1:0"
+	s.RaftDir = tmpDir
 
 	if err := s.Open(true, "node0"); err != nil {
 		t.Fatalf("failed to open store: %s", err)
@@ -123,14 +125,15 @@ func Test_StoreInMemOpenSingleNode(t *testing.T) {
 
 func Test_StoreStatus(t *testing.T) {
 	s := New(false)
-	tmpDir, _ := ioutil.TempDir("", "store_test")
+	tmpDir, _ := os.MkdirTemp("", "store_test")
 	defer os.RemoveAll(tmpDir)
 
-	s.RaftBind = "127.0.0.1:0"
-	s.RaftDir = tmpDir
 	if s == nil {
 		t.Fatalf("failed to create store")
 	}
+
+	s.RaftBind = "127.0.0.1:0"
+	s.RaftDir = tmpDir
 
 	if err := s.Open(true, "node0"); err != nil {
 		t.Fatalf("failed to open store: %s", err)


### PR DESCRIPTION
## Description
- replaced `deprivated ` code
  - `ioutil.ReadAll`  --> `io.ReadAll`
  - `ioutil.TempDir`  --> `os.MkdirTemp`
 


## Other Changes
- removed unnecessary `return`
- grouped `var` declerations in `main`
- moved `nil` check before, pointer usage in `store_test`

 

